### PR TITLE
fix: TSLint script and lint error

### DIFF
--- a/boilerplate/_package.json
+++ b/boilerplate/_package.json
@@ -17,7 +17,7 @@
     "tsc": "ets && tsc -p tsconfig.json",
     "ci": "npm run lint && npm run cov && npm run tsc",
     "autod": "autod",
-    "lint": "tslint .",
+    "lint": "tslint -p . -c tslint.json",
     "clean": "ets clean"
   },
   "dependencies": {

--- a/boilerplate/_package.json
+++ b/boilerplate/_package.json
@@ -17,7 +17,7 @@
     "tsc": "ets && tsc -p tsconfig.json",
     "ci": "npm run lint && npm run cov && npm run tsc",
     "autod": "autod",
-    "lint": "tslint -p . -c tslint.json",
+    "lint": "tslint --project . -c tslint.json",
     "clean": "ets clean"
   },
   "dependencies": {

--- a/boilerplate/app/service/Test.ts
+++ b/boilerplate/app/service/Test.ts
@@ -13,4 +13,3 @@ export default class Test extends Service {
     return `hi, ${name}`;
   }
 }
-


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复 `tslint` 无法正常使用的问题。并且修改了相关文件让其符合 `tslint` 规则

```
> tslint --project . -c tslint.json


app/service/Test.ts[17, 1]: Consecutive blank lines are forbidden
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! dist@1.0.0 lint: `tslint --project . -c tslint.json`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the dist@1.0.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
