### PR TITLE
chore: using egg-bin declarations instead of require

### DIFF
--- a/boilerplate/_package.json
+++ b/boilerplate/_package.json
@@ -5,7 +5,7 @@
   "private": true,
   "egg": {
     "typescript": true,
-    "require": ["egg-ts-helper/register"]
+    "declarations": true
   },
   "scripts": {
     "start": "egg-scripts start --daemon --title=egg-server-{{name}}",
@@ -32,9 +32,8 @@
     "autod": "^3.0.1",
     "autod-egg": "^1.1.0",
     "egg-ci": "^1.8.0",
-    "egg-bin": "^4.6.2",
+    "egg-bin": "^4.11.0",
     "egg-mock": "^3.16.0",
-    "egg-ts-helper": "^1.11.0",
     "tslib": "^1.9.0",
     "tslint": "^5.0.0",
     "tslint-config-egg": "^1.0.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Using egg-bin declarations instead of `egg.require`
