### PR TITLE
fix: use @eggjs/tracer@3

### DIFF
--- a/boilerplate/_package.json
+++ b/boilerplate/_package.json
@@ -31,7 +31,7 @@
     "@eggjs/tegg-schedule-plugin": "^3.5.2",
     "egg": "^4.0.0",
     "@eggjs/scripts": "^4.0.0",
-    "egg-tracer": "^2.0.0"
+    "@eggjs/tracer": "^3.0.0"
   },
   "devDependencies": {
     "@types/mocha": "10",

--- a/boilerplate/config/plugin.ts
+++ b/boilerplate/config/plugin.ts
@@ -27,7 +27,7 @@ const plugin: EggPlugin = {
   },
   tracer: {
     enable: true,
-    package: 'egg-tracer',
+    package: '@eggjs/tracer',
   },
 };
 


### PR DESCRIPTION
closes https://github.com/eggjs/tegg/issues/284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the tracer integration to its latest version, aligning with current package naming conventions for improved dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->